### PR TITLE
Enables CircleCI unit testing support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,33 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/python:3.7.2
+    working_directory: ~/repo
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - v1-dependencies-{{ checksum "requirements-test.txt" }}
+            # fallback to using the latest cache if no exact match is found
+            - v1-dependencies-
+      - run:
+          name: install dependencies
+          command: |
+            python3 -m venv venv
+            . venv/bin/activate
+            pip install -r requirements-test.txt
+      - save_cache:
+          paths:
+            - ./venv
+          key: v1-dependencies-{{ checksum "requirements-test.txt" }}
+      - run:
+          name: run tests
+          command: |
+            . venv/bin/activate
+            mkdir test-reports
+            pytest --junitxml=test-reports/junit.xml
+      - store_test_results:
+          path: test-reports
+      - store_artifacts:
+          path: test-reports 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # RLTrader (Formerly Bitcoin-Trader-RL)
 
+[![CircleCI](https://circleci.com/gh/notadamking/RLTrader.svg?style=svg)](https://circleci.com/gh/notadamking/RLTrader)
+
 In this series of articles, we've created and optimized a Bitcoin trading agent to be highly profitable using deep reinforcement learning.
 
 Discord server: https://discord.gg/ZZ7BGWh
@@ -21,6 +23,8 @@ pip install -r requirements.txt
 
 The requirements include the `tensorflow-gpu` library, though if you do not have access to a GPU, you should replace this requirement with `tensorflow`.
 
+To run the tests included with the library you'll need to addtionally install the libraries found in `requirements-test.txt`.
+
 # Optimizing, Training, and Testing
 
 While you could just let the agent train and run with the default PPO2 hyper-parameters, your agent would likely not be very profitable. The `stable-baselines` library provides a great set of default parameters that work for most problem domains, but we need to better.
@@ -40,9 +44,9 @@ From there, you can train an agent with the best set of hyper-parameters, and la
 If you would like to contribute, here is the roadmap for the future of this project. To assign yourself to an item, please create an Issue/PR titled with the item from below and I will add your name to the list.
 
 ## Stage 0:
-* Create a generic data loader for inputting multiple data sources (.csv, API, in-memory, etc.) **[sph3rex, @lukeB]**
+* Create a generic data loader for inputting multiple data sources (.csv, API, in-memory, etc.) **[@sph3rex, @lukeB, @notadamking]**
   * Map each data source to OHCLV format w/ same date/time format
-* Implement live trading capabilities
+* Implement live trading capabilities **[@notadamking]**
   * Allow model/agent to be passed in at run time
   * Allow live data to be saved in a format that can be later trained on
   * Enable paper-trading by default

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,5 @@
+pytest
+ccxt
+numpy
+pandas
+ta


### PR DESCRIPTION
This adds the required `config.yml` file that CircleCI needs to launch a container and run the tests defined in the `/test` folder.

Additionally, this adds a new `requirements-test.txt` file, which contains a subset of the libraries dependencies, as well as the `pytest` framework dependency. This file is used by the CI container to install any requirements, since without a GPU, we can't install things like `tensorflow-gpu`, etc. This has been noted in the README.

I've also added the markdown for an SVG badge to the README using your (@notadamking ) username, so it'll show as a broken link until you enable the project (if you end up choosing to do so) in CircleCI. 

Just a note that this is opened against the latest `data-providers` branch, since that's the only branch with tests on it currently.

You can see an example of the tests being run here: https://circleci.com/gh/ButkiewiczP/RLTrader/4