### PR TITLE
Convert dates on x-axis of test chart to a readable format

### DIFF
--- a/lib/env/render/TradingChart.py
+++ b/lib/env/render/TradingChart.py
@@ -140,7 +140,7 @@ class TradingChart:
         self._render_volume(step_range, times)
         self._render_trades(step_range, trades)
 
-        date_col = pd.to_datetime(self.df['Date'], unit='ms')
+        date_col = pd.to_datetime(self.df['Date'], unit='s').dt.strftime('%#m/%#d/%Y %H:%M')
         date_labels = date_col.values[step_range]
 
         self.price_ax.set_xticklabels(date_labels, rotation=45, horizontalalignment='right')


### PR DESCRIPTION
This fixes an issue with rendering the x-axis of the chart rendered during the `test` phase.

**Before:**
![Screenshot from 2019-07-08 23-12-01](https://user-images.githubusercontent.com/1395341/60856659-dbd84300-a1d5-11e9-9e05-96a0eb7d9114.png)



**After:**
![Screenshot from 2019-07-08 23-19-26](https://user-images.githubusercontent.com/1395341/60856936-d7605a00-a1d6-11e9-8322-f27a5df9ff89.png)
