### PR TITLE
Undefined name 'download_async'

### DIFF
--- a/lib/cli/functions/update_data.py
+++ b/lib/cli/functions/update_data.py
@@ -39,4 +39,4 @@ def download_data_async():
 
 
 if __name__ == '__main__':
-    download_async()
+    download_data_async()


### PR DESCRIPTION
[flake8](http://flake8.pycqa.org) testing of https://github.com/notadamking/RLTrader on Python 3.7.1

$ __flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics__
```
./lib/cli/functions/update_data.py:42:5: F821 undefined name 'download_async'
    download_async()
    ^
1     F821 undefined name 'download_async'
1
```
__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. These 5 are different from most other flake8 issues which are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree