### PR TITLE
logger error

### DIFF
--- a/lib/RLTrader.py
+++ b/lib/RLTrader.py
@@ -154,7 +154,7 @@ class RLTrader:
             trades = train_env.get_attr('trades')
 
             if len(trades[0]) < 1:
-                self.logger.info('Pruning trial for not making any trades: ', eval_idx)
+                self.logger.info(f'Pruning trial for not making any trades: {eval_idx}')
                 raise optuna.structs.TrialPruned()
 
             state = None


### PR DESCRIPTION
line 157 in RLTrader.py was throwing an error on python 3.

```
TypeError: not all arguments converted during string formatting
Call stack:
  File "./cli.py", line 32, in <module>
    proc.start()
 .......
 File "/home/null/RLTrader/lib/RLTrader.py", line 157, in optimize_params
    self.logger.info('Pruning trial for not making any trades: ', eval_idx)
Message: 'Pruning trial for not making any trades: '
Arguments: (1,)
```

All logger code is using f strings in RLTrader.py other than this line, this is a simple fix that changes this line to f string as well.