### PR TITLE
Specified the Optuna version

### DIFF
--- a/requirements.base.txt
+++ b/requirements.base.txt
@@ -4,7 +4,7 @@ sklearn
 matplotlib
 gym
 stable_baselines
-optuna
+optuna==0.10.0
 ta
 statsmodels==0.10.0rc2
 empyrical


### PR DESCRIPTION
Fix error: 
RuntimeError: The runtime optuna version 2.3.0 is no longer compatible with the table schema (set up by optuna 0.10.0). Please execute `$ optuna storage upgrade --storage $STORAGE_URL` for upgrading the storage. """