### PR TITLE
Update RLTrader.py

### DIFF
--- a/lib/RLTrader.py
+++ b/lib/RLTrader.py
@@ -289,7 +289,7 @@ class RLTrader:
 
                 if save_report:
                     reports_path = path.join('data', 'reports', f'{self.study_name}__{model_epoch}.html')
-                    qs.reports.html(returns.Balance, file=reports_path)
+                    qs.reports.html(returns.Balance, output=reports_path)
 
         self.logger.info(
             f'Finished testing model ({self.study_name}__{model_epoch}): ${"{:.2f}".format(np.sum(rewards))}')


### PR DESCRIPTION
**Issue**
`qs.report.html()` function signature doesn't support `file` as an argument.

Call results in: 
```
"TypeError: html() got an unexpected keyword argument 'file'". The correct argument is `output`. 
```

**Support**

`qs.report.html()` signature:
```
def html(returns, benchmark=None, rf=0., grayscale=False,
         title='Strategy Tearsheet', output=None, compounded=True,
         periods_per_year=252, download_filename='quantstats-tearsheet.html',
         figfmt='svg', template_path=None, match_dates=False):
```
- https://github.com/ranaroussi/quantstats/blob/6aaa65c20bad4c364efa7623375901925c036b45/quantstats/reports.py#L57 


and

Argument `output` usage:
```
    with open(output, 'w', encoding='utf-8') as f:
        f.write(tpl)
```
- https://github.com/ranaroussi/quantstats/blob/6aaa65c20bad4c364efa7623375901925c036b45/quantstats/reports.py#L250